### PR TITLE
Fix bug create project failed with Node.js@0.11.15.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -8,6 +8,17 @@ var OptionBuilder = require('./optionBuilder.js');
 var promptConfig = require('./promptConfig.js');
 var ProjectFiles = require('./projectFiles.js');
 
+var searchOfficialPlugins = function (callback) {
+  return cordova.searchPlugin('org.apache.cordova', function (plugins) {
+    // cordova plugin search error with Node.js@0.11.15
+    // If plugin search failed, use default plugin list.
+    if (!plugins || plugins.length <= 0) {
+      plugins = require('./plugins.js').default;
+    }
+    callback(plugins);
+  });
+};
+
 var GraybulletCordovaGenerator = yeoman.generators.Base.extend({
   constructor: function () {
     yeoman.Base.apply(this, arguments);
@@ -140,7 +151,7 @@ var GraybulletCordovaGenerator = yeoman.generators.Base.extend({
         }.bind(this));
       }.bind(this);
 
-      cordova.searchPlugin('org.apache.cordova', prompt);
+      searchOfficialPlugins(prompt);
     },
 
     /**


### PR DESCRIPTION
Fix bug create project failed with Node.js@0.11.15.

Plug-in list is not displayed.

```
$ yo graybullet-cordova

     _-----_
    |       |    .--------------------------.
    |--(o)--|    |   Welcome to the Apache  |
   `---------´   |    Cordova generator!    |
    ( _´U`_ )    '--------------------------'
    /___A___\    
     |  ~  |     
   __'.___.'__   
 ´   `  |° ´ Y ` 

? What is the name of Apache Cordova App? HelloCordova
? What is the ID of Apache Cordova App? io.cordova.hellocordova
? What app of the platform to be created? android
? Are you sure you want to add any plugins? (Press <space> to select)
```

And press enter, error.

```
? Are you sure you want to add any plugins? 
events.js:85
      throw er; // Unhandled 'error' event
            ^
Error: Command failed: cordova plugin add
You need to qualify `cordova plugin add` or `cordova plugin remove` with one or more plugins!

    at ChildProcess.exithandler (child_process.js:744:12)
    at ChildProcess.emit (events.js:110:17)
    at maybeClose (child_process.js:1008:16)
    at Socket.<anonymous> (child_process.js:1176:11)
    at Socket.emit (events.js:107:17)
    at Pipe.close (net.js:476:12)
```